### PR TITLE
exec, wait 남음

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,10 @@
 {
     "files.associations": {
         "thread.h": "c",
-        "filesys.h": "c",
-        "file.h": "c",
-        "off_t.h": "c",
-        "*.inc": "c"
+        "syscall.h": "c",
+        "*.inc": "c",
+        "syscall-nr.h": "c",
+        "main.h": "c",
+        "vaddr.h": "c"
     }
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -29,8 +30,8 @@ typedef int tid_t;
 #define PRI_MAX 63                      /* Highest priority. */
 
 /* Project2 - file Descriptor */
-#define FDT_PAGES 3
-#define FDCOUNT_LIMIT FDT_PAGES * (1 << 9)
+#define FDT_PAGES 2
+#define FDCOUNT_LIMIT 128
 
 
 /* A kernel thread or user process.
@@ -116,8 +117,14 @@ struct thread {
 	struct file *running;
 
 	/* Project 2 - parents : children process */
-	
 
+	struct intr_frame parent_if;
+	struct list child_process_list;
+	struct list_elem child_elem;
+
+	struct semaphore fork_sema;
+	struct semaphore free_sema;
+	struct semaphore wait_sema;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/lib/string.c
+++ b/lib/string.c
@@ -13,7 +13,7 @@ memcpy (void *dst_, const void *src_, size_t size) {
 
 	while (size-- > 0)
 		*dst++ = *src++;
-
+	
 	return dst_;
 }
 
@@ -304,7 +304,6 @@ strlcpy (char *dst, const char *src, size_t size) {
 
 	ASSERT (dst != NULL);
 	ASSERT (src != NULL);
-
 	src_len = strlen (src);
 	if (size > 0) {
 		size_t dst_len = size - 1;

--- a/tests/userprog/read-bad-ptr.c
+++ b/tests/userprog/read-bad-ptr.c
@@ -10,7 +10,6 @@ test_main (void)
 {
   int handle;
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  printf("test!!!!!");
   read(handle, (char *)0xc0100000, 123);
   fail ("should not have survived read()");
 }

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -75,7 +75,6 @@ sema_down (struct semaphore *sema) {
 		list_insert_ordered (&sema->waiters, &thread_current ()->elem, cmp_priority, 0);
 		thread_block ();
 	}
-
 	/* UP이 되어 while문을 빠져나온 다음 공유 자원을 차지했다. */
 	/* 자신이 공유자원을 사용중이므로 value를 DOWN한다. */
 	sema->value--;


### PR DESCRIPTION
pass tests/threads/priority-donate-chain
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
FAIL tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
15 of 95 tests failed.